### PR TITLE
Reduced crown chance, now displayed in leaderboard

### DIFF
--- a/packages/game/src/crown/chanceToFindCrown.ts
+++ b/packages/game/src/crown/chanceToFindCrown.ts
@@ -9,7 +9,7 @@ import store from '@adventure-bot/game/store'
 export function chanceToFindCrown(): number {
   const { gameStartedAt, bearerId } = store.getState().crown
   if (bearerId) return 0
-  const hoursElapsed = moment().diff(gameStartedAt, 'hours')
-  // exponential growth towards 1 in ~7 days
-  return Math.pow(2, hoursElapsed / 24) / 128
+  const days = moment().diff(gameStartedAt, 'hours') / 24
+  // logrithmic 0-1 for days 0-14
+  return (Math.pow(2, days) - 1) / Math.pow(2, 14)
 }

--- a/packages/game/src/leaderboard/leaderboardEmbeds.ts
+++ b/packages/game/src/leaderboard/leaderboardEmbeds.ts
@@ -4,6 +4,7 @@ import moment from 'moment'
 import { EmojiValue } from '@adventure-bot/game/Emoji'
 import { decoratedName } from '@adventure-bot/game/character'
 import { crownArt } from '@adventure-bot/game/crown'
+import { chanceToFindCrown } from '@adventure-bot/game/crown/chanceToFindCrown'
 import store from '@adventure-bot/game/store'
 import { selectBearer } from '@adventure-bot/game/store/selectors'
 import { timeTillSovereign } from '@adventure-bot/game/store/slices/crown'
@@ -31,6 +32,14 @@ export function leaderboardEmbeds(): MessageEmbed[] {
           bearer
         )} will win ${gameEndsAt.fromNow()}.`,
       }).setTimestamp(gameEndsAt.toDate())
+    )
+
+  if (!bearer)
+    embeds = embeds.concat(
+      new MessageEmbed({
+        title: 'Crown Chance',
+        description: EmojiValue('crown', chanceToFindCrown()),
+      })
     )
 
   if (leaderboard.length === 0)


### PR DESCRIPTION
Games are too short. Chance to find a crown reduced to approach 100% by day 14 instead of day 7.

Crown chance over time before (green) and after (red):
![image](https://user-images.githubusercontent.com/97096/174200246-e040cd3c-35d2-4f9a-8eac-d0991b03f4e1.png)

Crown chance now displayed on the leaderboard. 
![image](https://user-images.githubusercontent.com/97096/174200447-30747d3d-7ccf-4890-baa2-805e726a1cb8.png)