### PR TITLE
Status embeds show expiry in relative time, default duration doubled, durations standardized

### DIFF
--- a/packages/game/src/statusEffects/statusEffectEmbed.ts
+++ b/packages/game/src/statusEffects/statusEffectEmbed.ts
@@ -20,7 +20,9 @@ export function statusEffectEmbed(effect: StatusEffect): MessageEmbed {
   if (effect.started)
     fields.push({
       name: 'Expires',
-      value: moment(new Date(effect.started)).add(effect.duration).calendar(),
+      value: `<t:${moment(new Date(effect.started))
+        .add(effect.duration)
+        .unix()}:R>`,
     })
 
   if (effect.ticksRemaining)

--- a/packages/game/src/statusEffects/templates/aggression.ts
+++ b/packages/game/src/statusEffects/templates/aggression.ts
@@ -1,4 +1,5 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const aggression: EffectTemplate = {
   name: 'Agression',
@@ -9,5 +10,5 @@ export const aggression: EffectTemplate = {
   },
   announcement: 'became aggressive!',
   announcementColor: 'RED',
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
 }

--- a/packages/game/src/statusEffects/templates/defaultEffectDuration.ts
+++ b/packages/game/src/statusEffects/templates/defaultEffectDuration.ts
@@ -1,1 +1,1 @@
-export const defaultEffectDuration = 4 * 60 * 60000
+export const defaultEffectDuration = 8 * 60 * 60000

--- a/packages/game/src/statusEffects/templates/frailty.ts
+++ b/packages/game/src/statusEffects/templates/frailty.ts
@@ -1,10 +1,11 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const frailty: EffectTemplate = {
   name: 'Frailty',
   buff: false,
   debuff: true,
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
   modifiers: {
     ac: -3,
     maxHP: -3,

--- a/packages/game/src/statusEffects/templates/haste.ts
+++ b/packages/game/src/statusEffects/templates/haste.ts
@@ -1,4 +1,5 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const haste: EffectTemplate = {
   name: 'Haste',
@@ -7,7 +8,7 @@ export const haste: EffectTemplate = {
   modifiers: {
     haste: 10,
   },
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
   announcement: 'started moving faster!',
   announcementColor: 'WHITE',
 }

--- a/packages/game/src/statusEffects/templates/invigorated.ts
+++ b/packages/game/src/statusEffects/templates/invigorated.ts
@@ -1,10 +1,11 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const invigorated: EffectTemplate = {
   name: 'Invigorated',
   buff: true,
   debuff: false,
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
   modifiers: {
     maxHP: 2,
   },

--- a/packages/game/src/statusEffects/templates/might.ts
+++ b/packages/game/src/statusEffects/templates/might.ts
@@ -1,4 +1,5 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const might: EffectTemplate = {
   name: 'Might',
@@ -7,7 +8,7 @@ export const might: EffectTemplate = {
   modifiers: {
     damageMax: 2,
   },
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
   announcement: 'became mighty!',
   announcementColor: 'RED',
 }

--- a/packages/game/src/statusEffects/templates/protectedEffect.ts
+++ b/packages/game/src/statusEffects/templates/protectedEffect.ts
@@ -1,11 +1,12 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const protectedEffect: EffectTemplate = {
   name: 'Protected',
   modifiers: {
     ac: 2,
   },
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
   buff: true,
   debuff: false,
   announcement: 'became protected!',

--- a/packages/game/src/statusEffects/templates/slayer.ts
+++ b/packages/game/src/statusEffects/templates/slayer.ts
@@ -1,4 +1,5 @@
 import { EffectTemplate } from '@adventure-bot/game/statusEffects'
+import { defaultEffectDuration } from '@adventure-bot/game/statusEffects/templates/defaultEffectDuration'
 
 export const slayer: EffectTemplate = {
   name: 'Slayer',
@@ -7,7 +8,7 @@ export const slayer: EffectTemplate = {
   modifiers: {
     monsterDamageMax: 3,
   },
-  duration: 60 * 60000,
+  duration: defaultEffectDuration,
   announcement: 'became a slayer!',
   announcementColor: 'DARK_GREEN',
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/97096/235800236-3ccbe8d5-47f0-48b2-9398-a2ef740bd74a.png)
