### PR TITLE
Quest progress

### DIFF
--- a/packages/game/src/announcements/announceLoots.ts
+++ b/packages/game/src/announcements/announceLoots.ts
@@ -114,10 +114,8 @@ export function announceLoots(client: Client): void {
       channel.send({
         embeds: [
           new MessageEmbed({
-            title: `${decoratedName(looter)} looted ${decoratedName(target)}`,
-          })
-            .setImage(target.profile)
-            .setThumbnail(looter.profile),
+            title: `${looter.name} looted ${target.name}!`,
+          }),
           ...loot.itemsTaken.map((item) =>
             itemEmbed({ item }).setTitle(
               `${decoratedName(looter)} looted ${decoratedName(target)}'s ${

--- a/packages/game/src/announcements/announceQuestProgressed.ts
+++ b/packages/game/src/announcements/announceQuestProgressed.ts
@@ -1,0 +1,33 @@
+import { MessageEmbed, TextChannel } from 'discord.js'
+
+import { decoratedName } from '@adventure-bot/game/character'
+import { questProgressField } from '@adventure-bot/game/quest'
+import store from '@adventure-bot/game/store'
+import { startAppListening } from '@adventure-bot/game/store/listenerMiddleware'
+import { selectCharacterById } from '@adventure-bot/game/store/selectors'
+import { questProgressed } from '@adventure-bot/game/store/slices/characters'
+
+import { sendEmbeds } from './sendEmbeds'
+
+export function announceQuestProgressed(channel: TextChannel): void {
+  startAppListening({
+    actionCreator: questProgressed,
+    effect: async ({ payload: { characterId, questId, amount } }) => {
+      const character = selectCharacterById(store.getState(), characterId)
+      if (!character) return
+      const quest = character.quests[questId]
+      if (!quest) return
+
+      const embeds = [
+        new MessageEmbed({
+          title: `${decoratedName(
+            character
+          )} made ${amount} progress on their ${quest.title} quest!`,
+          fields: [questProgressField(quest, amount)],
+          color: 'YELLOW',
+        }),
+      ]
+      sendEmbeds({ channel, embeds })
+    },
+  })
+}

--- a/packages/game/src/announcements/index.ts
+++ b/packages/game/src/announcements/index.ts
@@ -4,9 +4,11 @@ export {
   announceLoots,
   announceCrownLoots,
 } from '@adventure-bot/game/announcements/announceLoots'
+export { announceGoldGained } from '@adventure-bot/game/announcements/announceGoldGained'
+export { announceGoldStolen } from '@adventure-bot/game/announcements/announceGoldStolen'
+export { announcePeriodicEffects } from '@adventure-bot/game/announcements/announcePeriodicEffects'
+export { announceStatContested } from '@adventure-bot/game/announcements/announceStatContested'
 export { announceTrapAttacked } from '@adventure-bot/game/announcements/announceTrapAttacked'
 export { announceWinners } from '@adventure-bot/game/announcements/announceWinners'
 export { announceXpAwarded } from '@adventure-bot/game/announcements/announceXpAwarded'
-export { announceGoldGained } from '@adventure-bot/game/announcements/announceGoldGained'
-export { announceGoldStolen } from '@adventure-bot/game/announcements/announceGoldStolen'
-export { announceStatContested } from '@adventure-bot/game/announcements/announceStatContested'
+export { announceQuestProgressed } from '@adventure-bot/game/announcements/announceQuestProgressed'

--- a/packages/game/src/attack/makeAttack.ts
+++ b/packages/game/src/attack/makeAttack.ts
@@ -1,4 +1,5 @@
 import { AttackResult } from '@adventure-bot/game/attack'
+import { updateQuestProgess } from '@adventure-bot/game/quest/updateQuestProgess'
 import { createEffect } from '@adventure-bot/game/statusEffects'
 import store from '@adventure-bot/game/store'
 import {
@@ -76,6 +77,8 @@ export function makeAttack({
         amount: totalDamage,
       })
     )
+    if (totalDamage < defender.hp)
+      updateQuestProgess(defender.id, 'survivor', totalDamage)
     if (attacker.pickpocket) {
       const amount = Math.min(defender.gold, d(attacker.pickpocket))
       store.dispatch(

--- a/packages/game/src/boot/setupGuild.ts
+++ b/packages/game/src/boot/setupGuild.ts
@@ -4,12 +4,13 @@ import {
   announceEffectAdded,
   announceGoldGained,
   announceGoldStolen,
+  announcePeriodicEffects,
+  announceQuestProgressed,
   announceStatContested,
   announceTrapAttacked,
   announceWinners,
   announceXpAwarded,
 } from '@adventure-bot/game/announcements'
-import { announcePeriodicEffects } from '@adventure-bot/game/announcements/announcePeriodicEffects'
 import { installCommands } from '@adventure-bot/game/boot/installCommands'
 import { renderCharacterList } from '@adventure-bot/game/character'
 import { renderLeaderboard } from '@adventure-bot/game/leaderboard'
@@ -40,6 +41,7 @@ export async function setupGuild({
     announceGoldGained(channel)
     announceGoldStolen(channel)
     announcePeriodicEffects(channel)
+    announceQuestProgressed(channel)
     announceStatContested(channel)
     announceTrapAttacked(channel)
     announceXpAwarded(channel)

--- a/packages/game/src/commands/heal.ts
+++ b/packages/game/src/commands/heal.ts
@@ -13,7 +13,6 @@ import quests from '@adventure-bot/game/commands/quests'
 import { heal } from '@adventure-bot/game/heal/heal'
 import {
   isUserQuestComplete,
-  questProgressField,
   updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
@@ -66,11 +65,7 @@ export const execute = async ({
             character: target,
             adjustment: result.amount,
           }),
-        ].concat(
-          character.quests.healer
-            ? questProgressField(character.quests.healer)
-            : []
-        ),
+        ],
       })
         .setImage(
           asset('fantasy', 'magic', 'a glowing hand applying healing magic')

--- a/packages/game/src/commands/heal.ts
+++ b/packages/game/src/commands/heal.ts
@@ -14,7 +14,7 @@ import { heal } from '@adventure-bot/game/heal/heal'
 import {
   isUserQuestComplete,
   questProgressField,
-  updateUserQuestProgess,
+  updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
@@ -44,7 +44,7 @@ export const execute = async ({
     await cooldowns.execute({ interaction })
     return
   }
-  updateUserQuestProgess(interaction.user, 'healer', result.amount)
+  updateQuestProgess(interaction.user.id, 'healer', result.amount)
 
   character = findOrCreateCharacter(interaction.user)
 

--- a/packages/game/src/commands/index.ts
+++ b/packages/game/src/commands/index.ts
@@ -20,7 +20,7 @@ import inspect from '@adventure-bot/game/commands/inspect/inspect'
 import inventory from '@adventure-bot/game/commands/inventory'
 import newgame from '@adventure-bot/game/commands/newgame'
 // import list from '@adventure-bot/game/commands/list/list'
-// import quests from '@adventure-bot/game/commands/quests'
+import quests from '@adventure-bot/game/commands/quests'
 // import renew from '@adventure-bot/game/commands/renew'
 import set from '@adventure-bot/game/commands/set'
 import { CommandHandler } from '@adventure-bot/game/utils'
@@ -42,7 +42,7 @@ commands.set('hp', hp)
 commands.set('inspect', inspect)
 commands.set('inventory', inventory)
 // commands.set('list', list)
-// commands.set('quests', quests)
+commands.set('quests', quests)
 // commands.set('renew', renew)
 commands.set('set', set)
 commands.set('newgame', newgame)

--- a/packages/game/src/encounters/encounterSummaryEmbed.ts
+++ b/packages/game/src/encounters/encounterSummaryEmbed.ts
@@ -1,6 +1,5 @@
 import { CommandInteraction, MessageEmbed } from 'discord.js'
 
-import { Emoji } from '@adventure-bot/game/Emoji'
 import { decoratedName } from '@adventure-bot/game/character'
 import { Encounter } from '@adventure-bot/game/encounters'
 import store from '@adventure-bot/game/store'

--- a/packages/game/src/encounters/fairyWell.ts
+++ b/packages/game/src/encounters/fairyWell.ts
@@ -9,7 +9,6 @@ import {
 import quests from '@adventure-bot/game/commands/quests'
 import {
   isUserQuestComplete,
-  questProgressField,
   updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
@@ -32,11 +31,7 @@ export async function fairyWell({
           'heal'
         )} +${healAmount}!`,
         color: 'DARK_VIVID_PINK',
-        fields: [hpBarField({ character, adjustment: healAmount })].concat(
-          character.quests.healer
-            ? questProgressField(character.quests.healer)
-            : []
-        ),
+        fields: [hpBarField({ character, adjustment: healAmount })],
       }).setImage(asset('fantasy', 'places', "a fairy's well").s3Url),
     ],
   })

--- a/packages/game/src/encounters/fairyWell.ts
+++ b/packages/game/src/encounters/fairyWell.ts
@@ -10,13 +10,10 @@ import quests from '@adventure-bot/game/commands/quests'
 import {
   isUserQuestComplete,
   questProgressField,
+  updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
-import {
-  healed,
-  questProgressed,
-  xpAwarded,
-} from '@adventure-bot/game/store/slices/characters'
+import { healed, xpAwarded } from '@adventure-bot/game/store/slices/characters'
 import { CommandHandlerOptions, asset, d } from '@adventure-bot/game/utils'
 
 export async function fairyWell({
@@ -52,13 +49,7 @@ export async function fairyWell({
       messageId: message.id,
     })
   )
-  store.dispatch(
-    questProgressed({
-      characterId: interaction.user.id,
-      questId: 'healer',
-      amount: healAmount,
-    })
-  )
+  updateQuestProgess(interaction.user.id, 'healer', healAmount)
   if (isUserQuestComplete(interaction.user, 'healer'))
     await quests.execute({ interaction })
 }

--- a/packages/game/src/encounters/fairyWell.ts
+++ b/packages/game/src/encounters/fairyWell.ts
@@ -2,6 +2,7 @@ import { Message, MessageEmbed } from 'discord.js'
 
 import { Emoji } from '@adventure-bot/game/Emoji'
 import {
+  awardXP,
   decoratedName,
   findOrCreateCharacter,
   hpBarField,
@@ -12,7 +13,7 @@ import {
   updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
-import { healed, xpAwarded } from '@adventure-bot/game/store/slices/characters'
+import { healed } from '@adventure-bot/game/store/slices/characters'
 import { CommandHandlerOptions, asset, d } from '@adventure-bot/game/utils'
 
 export async function fairyWell({
@@ -37,13 +38,7 @@ export async function fairyWell({
   })
   if (!(message instanceof Message)) return
   store.dispatch(healed({ character, amount: healAmount }))
-  store.dispatch(
-    xpAwarded({
-      characterId: interaction.user.id,
-      amount: 1,
-      messageId: message.id,
-    })
-  )
+  awardXP({ characterId: interaction.user.id, amount: 1 })
   updateQuestProgess(interaction.user.id, 'healer', healAmount)
   if (isUserQuestComplete(interaction.user, 'healer'))
     await quests.execute({ interaction })

--- a/packages/game/src/encounters/monster.ts
+++ b/packages/game/src/encounters/monster.ts
@@ -15,7 +15,7 @@ import { randomMonster } from '@adventure-bot/game/monster'
 import {
   isUserQuestComplete,
   questProgressField,
-  updateUserQuestProgess,
+  updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
 import { itemReceived } from '@adventure-bot/game/store/actions'
@@ -148,7 +148,7 @@ export const monster = async ({
           })
         )
         if (player.quests.slayer) {
-          updateUserQuestProgess(interaction.user, 'slayer', 1)
+          updateQuestProgess(interaction.user.id, 'slayer', 1)
           player = selectCharacterById(store.getState(), player.id) ?? player
         }
         break

--- a/packages/game/src/encounters/monster.ts
+++ b/packages/game/src/encounters/monster.ts
@@ -14,7 +14,6 @@ import { swordOfDragonSlaying } from '@adventure-bot/game/equipment/items'
 import { randomMonster } from '@adventure-bot/game/monster'
 import {
   isUserQuestComplete,
-  questProgressField,
   updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
@@ -207,8 +206,6 @@ export const monster = async ({
   })
 
   player = findOrCreateCharacter(interaction.user)
-  if (player && player.quests.slayer && encounter.outcome === 'player victory')
-    embed.addFields([questProgressField(player.quests.slayer)])
 
   const embeds = [embed]
 

--- a/packages/game/src/encounters/shrine/Shrine.ts
+++ b/packages/game/src/encounters/shrine/Shrine.ts
@@ -24,6 +24,5 @@ export async function shrineEncounter({
   const { id: messageId } = await interaction[replyType]({
     embeds: shrineEmbeds({ shrine, interaction }),
   })
-
   applyShrine({ shrine, interaction, messageId })
 }

--- a/packages/game/src/encounters/shrine/applyShrine.ts
+++ b/packages/game/src/encounters/shrine/applyShrine.ts
@@ -3,14 +3,14 @@ import { CommandInteraction } from 'discord.js'
 import { findOrCreateCharacter } from '@adventure-bot/game/character'
 import questsCommand from '@adventure-bot/game/commands/quests'
 import { Shrine } from '@adventure-bot/game/encounters/shrine'
-import { isUserQuestComplete } from '@adventure-bot/game/quest'
+import {
+  isUserQuestComplete,
+  updateQuestProgess,
+} from '@adventure-bot/game/quest'
 import { effects } from '@adventure-bot/game/statusEffects'
 import store from '@adventure-bot/game/store'
 import { selectCharacterEffects } from '@adventure-bot/game/store/selectors'
-import {
-  questProgressed,
-  xpAwarded,
-} from '@adventure-bot/game/store/slices/characters'
+import { xpAwarded } from '@adventure-bot/game/store/slices/characters'
 import { effectAdded } from '@adventure-bot/game/store/slices/statusEffects'
 
 export async function applyShrine({
@@ -38,14 +38,7 @@ export async function applyShrine({
       messageId,
     })
   )
-
-  store.dispatch(
-    questProgressed({
-      characterId: interaction.user.id,
-      questId: 'blessed',
-      amount: 1,
-    })
-  )
+  updateQuestProgess(interaction.user.id, 'blessed', 1)
 
   store.dispatch(
     xpAwarded({

--- a/packages/game/src/encounters/shrine/shrineEmbeds.ts
+++ b/packages/game/src/encounters/shrine/shrineEmbeds.ts
@@ -5,7 +5,6 @@ import {
   findOrCreateCharacter,
 } from '@adventure-bot/game/character'
 import { Shrine } from '@adventure-bot/game/encounters/shrine'
-import { questProgressField } from '@adventure-bot/game/quest'
 
 export function shrineEmbeds({
   shrine,
@@ -15,12 +14,10 @@ export function shrineEmbeds({
   interaction: CommandInteraction
 }): MessageEmbed[] {
   const character = findOrCreateCharacter(interaction.user)
-  const { blessed } = character.quests
   return [
     new MessageEmbed({
       title: `${decoratedName(character)} encountered a ${shrine.name}!`,
       description: shrine.description,
-      fields: blessed ? [questProgressField(blessed)] : [],
       color: shrine.color,
     })
       .setImage(shrine.image)

--- a/packages/game/src/encounters/tavern/barFight.ts
+++ b/packages/game/src/encounters/tavern/barFight.ts
@@ -7,7 +7,7 @@ import {
 } from '@adventure-bot/game/character'
 import {
   questProgressField,
-  updateUserQuestProgess,
+  updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
 import { damaged, xpAwarded } from '@adventure-bot/game/store/slices/characters'
@@ -34,7 +34,8 @@ export async function barFight(
     .setImage(asset('fantasy', 'places', 'drunken bar brawl in a tavern').s3Url)
     .setThumbnail(character.profile)
   if (character.hp > 0 && character.quests.survivor) {
-    const updated = updateUserQuestProgess(interaction.user, 'survivor', damage)
+    updateQuestProgess(interaction.user.id, 'survivor', damage)
+    const updated = findOrCreateCharacter(interaction.user)
     if (updated && updated.quests.survivor)
       embed.addFields([questProgressField(updated.quests.survivor)])
   }

--- a/packages/game/src/encounters/tavern/barFight.ts
+++ b/packages/game/src/encounters/tavern/barFight.ts
@@ -1,13 +1,14 @@
 import { CommandInteraction, MessageEmbed } from 'discord.js'
 
 import {
+  awardXP,
   decoratedName,
   findOrCreateCharacter,
   hpBarField,
 } from '@adventure-bot/game/character'
 import { updateQuestProgess } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
-import { damaged, xpAwarded } from '@adventure-bot/game/store/slices/characters'
+import { damaged } from '@adventure-bot/game/store/slices/characters'
 import { asset, d6 } from '@adventure-bot/game/utils'
 
 export async function barFight(
@@ -30,12 +31,11 @@ export async function barFight(
   })
     .setImage(asset('fantasy', 'places', 'drunken bar brawl in a tavern').s3Url)
     .setThumbnail(character.profile)
-  if (character.hp > 0 && character.quests.survivor) {
+  if (damage < character.hp)
     updateQuestProgess(interaction.user.id, 'survivor', damage)
-  }
 
   await interaction[followUp ? 'followUp' : 'reply']({
     embeds: [embed],
   })
-  store.dispatch(xpAwarded({ characterId: interaction.user.id, amount: 1 }))
+  awardXP({ characterId: interaction.user.id, amount: 1 })
 }

--- a/packages/game/src/encounters/tavern/barFight.ts
+++ b/packages/game/src/encounters/tavern/barFight.ts
@@ -5,10 +5,7 @@ import {
   findOrCreateCharacter,
   hpBarField,
 } from '@adventure-bot/game/character'
-import {
-  questProgressField,
-  updateQuestProgess,
-} from '@adventure-bot/game/quest'
+import { updateQuestProgess } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
 import { damaged, xpAwarded } from '@adventure-bot/game/store/slices/characters'
 import { asset, d6 } from '@adventure-bot/game/utils'
@@ -35,9 +32,6 @@ export async function barFight(
     .setThumbnail(character.profile)
   if (character.hp > 0 && character.quests.survivor) {
     updateQuestProgess(interaction.user.id, 'survivor', damage)
-    const updated = findOrCreateCharacter(interaction.user)
-    if (updated && updated.quests.survivor)
-      embed.addFields([questProgressField(updated.quests.survivor)])
   }
 
   await interaction[followUp ? 'followUp' : 'reply']({

--- a/packages/game/src/encounters/tavern/restfulNight.ts
+++ b/packages/game/src/encounters/tavern/restfulNight.ts
@@ -9,14 +9,11 @@ import quests from '@adventure-bot/game/commands/quests'
 import {
   isUserQuestComplete,
   questProgressField,
+  updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import { createEffect } from '@adventure-bot/game/statusEffects'
 import store from '@adventure-bot/game/store'
-import {
-  healed,
-  questProgressed,
-  xpAwarded,
-} from '@adventure-bot/game/store/slices/characters'
+import { healed, xpAwarded } from '@adventure-bot/game/store/slices/characters'
 import { effectAdded } from '@adventure-bot/game/store/slices/statusEffects'
 import { asset } from '@adventure-bot/game/utils'
 
@@ -64,13 +61,7 @@ export async function restfulNight(
     ],
   })
 
-  store.dispatch(
-    questProgressed({
-      characterId: interaction.user.id,
-      questId: 'healer',
-      amount: amountHealed,
-    })
-  )
+  updateQuestProgess(interaction.user.id, 'healer', amountHealed)
 
   store.dispatch(
     xpAwarded({

--- a/packages/game/src/encounters/tavern/restfulNight.ts
+++ b/packages/game/src/encounters/tavern/restfulNight.ts
@@ -8,7 +8,6 @@ import {
 import quests from '@adventure-bot/game/commands/quests'
 import {
   isUserQuestComplete,
-  questProgressField,
   updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import { createEffect } from '@adventure-bot/game/statusEffects'
@@ -50,11 +49,7 @@ export async function restfulNight(
             character,
             adjustment: amountHealed,
           }),
-        ].concat(
-          character.quests.healer
-            ? questProgressField(character.quests.healer)
-            : []
-        ),
+        ],
       })
         .setImage(asset('fantasy', 'places', 'restful tavern').s3Url)
         .setThumbnail(character.profile),

--- a/packages/game/src/encounters/travel.ts
+++ b/packages/game/src/encounters/travel.ts
@@ -13,14 +13,12 @@ import { isTravelersRing } from '@adventure-bot/game/equipment/items/travelersRi
 import {
   isUserQuestComplete,
   questProgressField,
+  updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import { createEffect, effects } from '@adventure-bot/game/statusEffects'
 import store from '@adventure-bot/game/store'
 import { selectCharacterEffects } from '@adventure-bot/game/store/selectors'
-import {
-  healed,
-  questProgressed,
-} from '@adventure-bot/game/store/slices/characters'
+import { healed } from '@adventure-bot/game/store/slices/characters'
 import { effectAdded } from '@adventure-bot/game/store/slices/statusEffects'
 import { CommandHandlerOptions, asset, d } from '@adventure-bot/game/utils'
 
@@ -28,13 +26,7 @@ export const travel = async ({
   interaction,
   replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
-  store.dispatch(
-    questProgressed({
-      characterId: interaction.user.id,
-      questId: 'traveler',
-      amount: 1,
-    })
-  )
+  updateQuestProgess(interaction.user.id, 'traveler', 1)
   const character = findOrCreateCharacter(interaction.user)
   const { traveler } = character.quests
   const message = await interaction[replyType]({

--- a/packages/game/src/encounters/travel.ts
+++ b/packages/game/src/encounters/travel.ts
@@ -12,7 +12,6 @@ import questsCommand from '@adventure-bot/game/commands/quests'
 import { isTravelersRing } from '@adventure-bot/game/equipment/items/travelersRing'
 import {
   isUserQuestComplete,
-  questProgressField,
   updateQuestProgess,
 } from '@adventure-bot/game/quest'
 import { createEffect, effects } from '@adventure-bot/game/statusEffects'
@@ -28,14 +27,11 @@ export const travel = async ({
 }: CommandHandlerOptions): Promise<void> => {
   updateQuestProgess(interaction.user.id, 'traveler', 1)
   const character = findOrCreateCharacter(interaction.user)
-  const { traveler } = character.quests
   const message = await interaction[replyType]({
     embeds: [
       new MessageEmbed({
         title: `${decoratedName(character)} traveled.`,
         color: 'GREEN',
-        fields: traveler ? [questProgressField(traveler)] : [],
-
         description: `You travel the lands.`,
       }).setImage(asset('fantasy', 'places', 'travel').s3Url),
     ],

--- a/packages/game/src/quest/index.ts
+++ b/packages/game/src/quest/index.ts
@@ -15,7 +15,7 @@ import {
   slayerBuffQuestReward,
   survivorBuffQuestReward,
 } from '@adventure-bot/game/quest/rewards'
-import { updateUserQuestProgess } from '@adventure-bot/game/quest/updateQuestProgess'
+import { updateQuestProgess } from '@adventure-bot/game/quest/updateQuestProgess'
 
 export {
   quests,
@@ -23,7 +23,7 @@ export {
   questProgressBar,
   questProgressField,
   isQuestId,
-  updateUserQuestProgess,
+  updateQuestProgess,
   QuestId,
   blessedBuffQuestReward,
   getCompletedQuests,

--- a/packages/game/src/quest/questProgressField.ts
+++ b/packages/game/src/quest/questProgressField.ts
@@ -2,8 +2,11 @@ import { EmbedField } from 'discord.js'
 
 import { Quest, questProgressBar } from '@adventure-bot/game/quest'
 
-export const questProgressField = (quest: Quest): EmbedField => ({
-  name: quest.title,
+export const questProgressField = (
+  quest: Quest,
+  amount?: number
+): EmbedField => ({
+  name: `${quest.title} ${amount ? `(+${amount})` : ''}`,
   value: `${questProgressBar(quest)} ${quest.progress}/${quest.totalRequired}`,
   inline: true,
 })

--- a/packages/game/src/quest/updateQuestProgess.ts
+++ b/packages/game/src/quest/updateQuestProgess.ts
@@ -1,5 +1,6 @@
 import { QuestId } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
+import { selectCharacterById } from '@adventure-bot/game/store/selectors'
 import { questProgressed } from '@adventure-bot/game/store/slices/characters'
 
 export const updateQuestProgess = (
@@ -7,6 +8,12 @@ export const updateQuestProgess = (
   questId: QuestId,
   amount: number
 ): void => {
+  const character = selectCharacterById(store.getState(), characterId)
+  if (!character) return
+  const quest = character.quests[questId]
+  if (!quest) return
+  if (quest.progress >= quest.totalRequired) return
+
   store.dispatch(
     questProgressed({
       characterId,

--- a/packages/game/src/quest/updateQuestProgess.ts
+++ b/packages/game/src/quest/updateQuestProgess.ts
@@ -1,22 +1,17 @@
-import { User } from 'discord.js'
-
-import { Character, findOrCreateCharacter } from '@adventure-bot/game/character'
 import { QuestId } from '@adventure-bot/game/quest'
 import store from '@adventure-bot/game/store'
 import { questProgressed } from '@adventure-bot/game/store/slices/characters'
 
-export const updateUserQuestProgess = (
-  user: User,
+export const updateQuestProgess = (
+  characterId: string,
   questId: QuestId,
-  change: number
-): Character => {
+  amount: number
+): void => {
   store.dispatch(
     questProgressed({
-      characterId: user.id,
+      characterId,
       questId,
-      amount: change,
+      amount,
     })
   )
-
-  return findOrCreateCharacter(user)
 }

--- a/packages/game/src/store/slices/characters.ts
+++ b/packages/game/src/store/slices/characters.ts
@@ -76,6 +76,8 @@ const characterSlice = createSlice({
       const quest = state.charactersById[characterId].quests[questId]
       if (!quest) return
       quest.progress += amount
+      if (quest.progress > quest.totalRequired)
+        quest.progress = quest.totalRequired
     },
 
     questCompleted(

--- a/packages/game/src/trap/trapAttack.ts
+++ b/packages/game/src/trap/trapAttack.ts
@@ -1,12 +1,10 @@
-import { awardXP, getCharacter } from '@adventure-bot/game/character'
+import { awardXP } from '@adventure-bot/game/character'
+import { updateQuestProgess } from '@adventure-bot/game/quest'
 import { createEffect } from '@adventure-bot/game/statusEffects'
 import store from '@adventure-bot/game/store'
 import { trapAttacked } from '@adventure-bot/game/store/actions'
 import { CharacterWithStats } from '@adventure-bot/game/store/selectors'
-import {
-  damaged,
-  questProgressed,
-} from '@adventure-bot/game/store/slices/characters'
+import { damaged } from '@adventure-bot/game/store/slices/characters'
 import { effectAdded } from '@adventure-bot/game/store/slices/statusEffects'
 import { TrapAttackResult, TrapWithStats } from '@adventure-bot/game/trap'
 import { d, d20 } from '@adventure-bot/game/utils'
@@ -54,14 +52,8 @@ export function trapAttack({
           amount: damage,
         })
       )
-      if (getCharacter(defender.id)?.hp ?? 0 > 0)
-        store.dispatch(
-          questProgressed({
-            characterId: defender.id,
-            questId: 'survivor',
-            amount: damage,
-          })
-        )
+      if (damage < defender.hp)
+        updateQuestProgess(defender.id, 'survivor', damage)
     }
   }
 


### PR DESCRIPTION
All quest progress is generally announced. Hopefully this isn't too noisy.

![image](https://github.com/Adventure-Bot/adventure-bot/assets/97096/15bf55a1-88a0-4e40-b69e-e3b02a47a355)

Quests can no longer go above 100%.

Attacks in combat give survivor quest progress as intended.

The `/quest` command has been restored.