### PR TITLE
consolidate followUp/reply/editReply to channel.send

### DIFF
--- a/packages/game/src/announcements/announceItemsReceived.ts
+++ b/packages/game/src/announcements/announceItemsReceived.ts
@@ -16,7 +16,7 @@ export function announceItemsReceived(): void {
     effect: ({ payload: { item, interaction, characterId } }) => {
       const character = selectCharacterById(store.getState(), characterId)
       if (!character) return
-      interaction.followUp({
+      interaction.channel?.send({
         content: `${decoratedName(character)} received: ${item.name}!`,
         embeds: [itemEmbed({ item })],
       })
@@ -30,7 +30,7 @@ export function announceItemsReceived(): void {
     effect: ({ payload: { item, interaction, characterId } }) => {
       const character = selectCharacterById(store.getState(), characterId)
       if (!character) return
-      interaction.followUp({
+      interaction.channel?.send({
         content: `${decoratedName(character)} purchased: ${item.name}!`,
         embeds: [itemEmbed({ item })],
       })

--- a/packages/game/src/announcements/announceQuestProgress.ts
+++ b/packages/game/src/announcements/announceQuestProgress.ts
@@ -35,8 +35,7 @@ export function announceQuestProgress(channel: TextChannel): void {
           }),
         ],
       })
-      if (isComplete)
-        await quests.execute({ interaction, replyType: 'followUp' })
+      if (isComplete) await quests.execute({ interaction })
     },
   })
 }

--- a/packages/game/src/announcements/announceTrapAttacked.ts
+++ b/packages/game/src/announcements/announceTrapAttacked.ts
@@ -11,7 +11,7 @@ export function announceTrapAttacked(channel: TextChannel): void {
   startAppListening({
     actionCreator: trapAttacked,
     effect: ({ payload }) => {
-      const { messageId, result } = payload
+      const { result } = payload
       const { trap, defender, outcome, damage } = result
       const embed = new EmbedBuilder({
         title: `${Emoji(outcome)} ${decoratedName(defender)} was ${
@@ -28,7 +28,7 @@ export function announceTrapAttacked(channel: TextChannel): void {
       }
       sendEmbeds({
         channel,
-        messageId,
+
         embeds: [embed],
       })
     },

--- a/packages/game/src/announcements/announceWinners.ts
+++ b/packages/game/src/announcements/announceWinners.ts
@@ -37,7 +37,7 @@ export function announceWinners(channel: TextChannel): void {
         ...leaderboardEmbeds(),
       ]
       if (interaction) {
-        interaction.editReply({ embeds })
+        interaction.channel?.send({ embeds })
         return
       }
       channel.send({

--- a/packages/game/src/announcements/sendEmbeds.ts
+++ b/packages/game/src/announcements/sendEmbeds.ts
@@ -1,7 +1,7 @@
 import { EmbedBuilder, Message, TextChannel } from 'discord.js'
 
+// todo: remove this no longer helpful abstraction
 export async function sendEmbeds({
-  messageId,
   channel,
   embeds,
 }: {
@@ -9,13 +9,5 @@ export async function sendEmbeds({
   embeds: EmbedBuilder[]
   messageId?: string
 }): Promise<Message> {
-  const message = messageId
-    ? await channel.messages.fetch(messageId).catch(() => null)
-    : null
-
-  if (message) {
-    return message.reply({ embeds })
-  } else {
-    return channel.send({ embeds })
-  }
+  return channel.send({ embeds })
 }

--- a/packages/game/src/boot/createClient.ts
+++ b/packages/game/src/boot/createClient.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Partials } from 'discord.js'
+import { ChannelType, Client, GatewayIntentBits, Partials } from 'discord.js'
 
 import {
   announceCrownLoots,
@@ -45,21 +45,27 @@ export async function createClient({
 
   client.on('interactionCreate', async (interaction) => {
     if (!interaction.isCommand()) return
+
+    interaction.reply(`${interaction.user} used /${interaction.commandName}`)
+
+    const channel = interaction.channel
+    if (!channel || channel.type !== ChannelType.GuildText) return
     store.dispatch(commandUsed(interaction))
+    channel.sendTyping()
     console.log(`command ${interaction.commandName}`)
     console.time(interaction.commandName + ' ' + interaction.id)
+
     try {
-      await interaction.deferReply()
       const command = commands.get(interaction.commandName)
       if (!command) {
-        interaction.editReply(`Command not found ${interaction.commandName}`)
+        channel.send(`Command not found ${interaction.commandName}`)
         return
       }
       await command.execute({ interaction })
     } catch (e) {
       console.error(e)
       try {
-        await interaction.followUp(
+        await channel.send(
           `Command \`${interaction.commandName}\` failed with error: \`${e}\``
         )
       } catch {

--- a/packages/game/src/commands/admin/admin.ts
+++ b/packages/game/src/commands/admin/admin.ts
@@ -85,17 +85,17 @@ export const execute = async ({
       break
     case 'purge_roaming':
       store.dispatch(purgeRoamingMonsters())
-      interaction.editReply('Roaming monsters purged')
+      interaction.channel?.send('Roaming monsters purged')
       break
     case 'set_xp':
       setXp(interaction)
-      interaction.editReply(
+      interaction.channel?.send(
         `XP set to ${interaction.options.getInteger('xp')}.`
       )
       break
     case 'set_gold':
       setGold(interaction)
-      interaction.editReply('Gold set.')
+      interaction.channel?.send('Gold set.')
       return
     case 'set_health':
       setHealth(interaction)
@@ -105,17 +105,17 @@ export const execute = async ({
       break
     case 'declare_winner_revoked':
       store.dispatch(winnerRevoked())
-      interaction.editReply({
+      interaction.channel?.send({
         embeds: leaderboardEmbeds(),
       })
       break
     case 'leaderboard':
-      interaction.editReply({
+      interaction.channel?.send({
         embeds: leaderboardEmbeds(),
       })
       break
     default:
-      interaction.editReply(
+      interaction.channel?.send(
         `Invalid subcommand ${interaction.options.getSubcommand()}`
       )
   }
@@ -141,16 +141,16 @@ async function addEmoji(interaction: ChatInputCommandInteraction) {
         (emoji) => emoji.name === emojiName
       )
       if (existing) {
-        interaction.editReply(`Emoji already exists: ${existing}`)
+        interaction.channel?.send(`Emoji already exists: ${existing}`)
         return
       }
       const emoji = await guild.emojis.create({
         attachment: file,
         name: emojiName,
       })
-      interaction.editReply(`Emoji added: ${emoji}`)
+      interaction.channel?.send(`Emoji added: ${emoji}`)
     } catch (e) {
-      interaction.editReply(`Error: ${e}`)
+      interaction.channel?.send(`Error: ${e}`)
     }
   })
 }
@@ -179,7 +179,7 @@ const setXp = async (interaction: ChatInputCommandInteraction) => {
 const setHealth = async (interaction: ChatInputCommandInteraction) => {
   const hp = interaction.options.getInteger('hp')
   if (hp === null) return
-  interaction.editReply(`Health set to ${hp}.`)
+  interaction.channel?.send(`Health set to ${hp}.`)
   store.dispatch(
     healthSet({
       characterId: interaction.user.id,

--- a/packages/game/src/commands/admin/cleanse.ts
+++ b/packages/game/src/commands/admin/cleanse.ts
@@ -12,7 +12,7 @@ export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
   store.dispatch(characterCleansed({ characterId: interaction.user.id }))
-  interaction.followUp(`${interaction.user.username} cleansed themself`)
+  interaction.channel?.send(`${interaction.user.username} cleansed themself`)
 }
 
 export default { command, execute }

--- a/packages/game/src/commands/admin/effect.ts
+++ b/packages/game/src/commands/admin/effect.ts
@@ -26,7 +26,7 @@ export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} conjures an effect!`,
@@ -43,7 +43,7 @@ export const execute = async ({
     const input = parseInt(message.content)
     const effect = values(effects)[input - 1]
     if (!effect) {
-      interaction.editReply(`That's not a valid effect.`)
+      interaction.channel?.send(`That's not a valid effect.`)
       return
     }
     store.dispatch(

--- a/packages/game/src/commands/admin/encounter.ts
+++ b/packages/game/src/commands/admin/encounter.ts
@@ -20,7 +20,7 @@ function encounterList(): string {
 export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(
@@ -42,10 +42,10 @@ export const execute = async ({
     const encounter = encountersByName[input - 1]
     if (!encounter) return
     if (!encounter[1]) {
-      interaction.editReply(`That's not a valid encounter.`)
+      interaction.channel?.send(`That's not a valid encounter.`)
       return
     }
-    encounter[1]({ interaction, replyType: 'followUp' })
+    encounter[1]({ interaction })
   })
 }
 

--- a/packages/game/src/commands/admin/item.ts
+++ b/packages/game/src/commands/admin/item.ts
@@ -23,7 +23,7 @@ function itemList(): string {
 export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(
@@ -42,7 +42,7 @@ export const execute = async ({
     const input = parseInt(message.content)
     const createItem = values(items)[input - 1]
     if (!createItem) {
-      interaction.editReply(`That's not a valid item.`)
+      interaction.channel?.send(`That's not a valid item.`)
       return
     }
     store.dispatch(

--- a/packages/game/src/commands/admin/lootmonster.ts
+++ b/packages/game/src/commands/admin/lootmonster.ts
@@ -15,7 +15,7 @@ export const command = new SlashCommandBuilder()
 export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(
@@ -33,7 +33,7 @@ export const execute = async ({
   collector.on('collect', async (message) => {
     const input = parseInt(message.content)
     if (!monstersByName[input - 1]) {
-      interaction.editReply(`That's not a valid monster.`)
+      interaction.channel?.send(`That's not a valid monster.`)
       return
     }
     const monster = monstersByName[input - 1][1]()

--- a/packages/game/src/commands/admin/monster.ts
+++ b/packages/game/src/commands/admin/monster.ts
@@ -19,7 +19,7 @@ export const command = new SlashCommandBuilder()
 export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(
@@ -39,12 +39,11 @@ export const execute = async ({
     const input = parseInt(message.content)
     const selectedMonster = monstersByName[input - 1]
     if (!selectedMonster) {
-      interaction.followUp(`${selectedMonster} is not a valid choice.`)
+      interaction.channel?.send(`${selectedMonster} is not a valid choice.`)
       return
     }
     monster({
       interaction,
-      replyType: 'followUp',
       monster: createMonster(selectedMonster[1]()),
     })
     collector.stop()

--- a/packages/game/src/commands/adventure.ts
+++ b/packages/game/src/commands/adventure.ts
@@ -20,7 +20,7 @@ export const execute = async ({
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
   if (character.hp === 0) {
-    await interaction.editReply({
+    await interaction.channel?.send({
       embeds: [
         new EmbedBuilder()
           .setDescription(`You're too weak to press on.`)
@@ -41,7 +41,7 @@ export const execute = async ({
   const encounter = randomEncounter(interaction)
   console.log(encounter)
   await encounter({ interaction })
-  await interaction.followUp(
+  await interaction.channel?.send(
     character.name +
       ' can ' +
       Emoji('adventure') +

--- a/packages/game/src/commands/attack.ts
+++ b/packages/game/src/commands/attack.ts
@@ -24,14 +24,14 @@ export const execute = async ({
   const targetUser = interaction.options.data[0].user
   const initiatorUser = interaction.user
   if (!targetUser) {
-    await interaction.editReply(`You must specify a target @player`)
+    await interaction.channel?.send(`You must specify a target @player`)
     return
   }
 
   const initiator = findOrCreateCharacter(initiatorUser)
   const target = findOrCreateCharacter(targetUser)
   if (initiator.hp === 0) {
-    await interaction.editReply({
+    await interaction.channel?.send({
       embeds: [
         new EmbedBuilder({
           description: `You're too weak to press on.`,
@@ -54,7 +54,7 @@ export const execute = async ({
       interaction,
     })
   }
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds,
   })
   await sleep(2000)
@@ -66,7 +66,7 @@ export const execute = async ({
       defender: initiator,
     })
     if (!retaliationResult) {
-      await interaction.editReply({
+      await interaction.channel?.send({
         content: `No attack result or retaliation outcome is cooldown. This should not happen.`,
       })
       return
@@ -82,7 +82,7 @@ export const execute = async ({
       })
     }
 
-    await interaction.followUp({
+    await interaction.channel?.send({
       embeds: retaliationEmbeds,
     })
   }

--- a/packages/game/src/commands/buyItem.ts
+++ b/packages/game/src/commands/buyItem.ts
@@ -11,7 +11,7 @@ export const buyItem = async (
   item: Item
 ): Promise<void> => {
   if (player.gold < item.goldValue) {
-    await interaction.followUp(
+    await interaction.channel?.send(
       `You cannot afford the ${item.name}. You have only ${player.gold} gold and it costs ${item.goldValue}.`
     )
     return

--- a/packages/game/src/commands/cooldowns.ts
+++ b/packages/game/src/commands/cooldowns.ts
@@ -16,7 +16,7 @@ export const execute = async ({
   findOrCreateCharacter(interaction.user)
   const character = selectCharacterById(store.getState(), interaction.user.id)
   if (!character) return
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [cooldownsEmbed({ character, interaction })],
   })
 }

--- a/packages/game/src/commands/d20.ts
+++ b/packages/game/src/commands/d20.ts
@@ -10,7 +10,7 @@ export const command = new SlashCommandBuilder()
 export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
-  interaction.editReply({
+  interaction.channel?.send({
     content: d20Emoji(d20()),
   })
 }

--- a/packages/game/src/commands/heal.ts
+++ b/packages/game/src/commands/heal.ts
@@ -49,7 +49,7 @@ export const execute = async ({
   const maybeOnTarget =
     target.id === character.id ? '' : ' on ' + decoratedName(target)
 
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         color: Colors.White,

--- a/packages/game/src/commands/hp.ts
+++ b/packages/game/src/commands/hp.ts
@@ -13,7 +13,7 @@ export const command = new SlashCommandBuilder()
 export const execute = async ({
   interaction,
 }: CommandHandlerOptions): Promise<void> => {
-  interaction.editReply({
+  interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         fields: [

--- a/packages/game/src/commands/hpbartest.ts
+++ b/packages/game/src/commands/hpbartest.ts
@@ -26,7 +26,7 @@ export const execute = async ({
     maxHP: 10,
   })
 
-  interaction.editReply({
+  interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: 'Heal',

--- a/packages/game/src/commands/inspect/inspect.ts
+++ b/packages/game/src/commands/inspect/inspect.ts
@@ -38,7 +38,7 @@ export const execute = async ({
   const character = selectCharacterById(store.getState(), user.id)
   if (!character) return
 
-  await interaction.followUp({
+  await interaction.channel?.send({
     embeds: [
       characterEmbed({ character }),
       statsEmbed({ character, interaction }),

--- a/packages/game/src/commands/inventory.ts
+++ b/packages/game/src/commands/inventory.ts
@@ -34,11 +34,11 @@ export const execute = async ({
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
   if (!character.inventory.length) {
-    await interaction.followUp('Your inventory is empty.')
+    await interaction.channel?.send('Your inventory is empty.')
     return
   }
-  const message = await interaction.followUp({
-    content: `${decoratedName(character)}'s checks their bags.`,
+  const message = await interaction.channel?.send({
+    content: `${decoratedName(character)} checks their bags.`,
     components: [inventoryComponents(interaction)],
   })
   if (!(message instanceof Message)) return
@@ -52,7 +52,7 @@ export const execute = async ({
     channel,
   })
   if (!hook) {
-    await interaction.followUp(`Inventory hook not found.`)
+    await interaction.channel?.send(`Inventory hook not found.`)
     return
   }
 

--- a/packages/game/src/commands/list/listCharacters.ts
+++ b/packages/game/src/commands/list/listCharacters.ts
@@ -21,7 +21,7 @@ export async function listCharacters(
     .sort((a, b) => b.xp - a.xp)
     .slice(0, 10)
     .map((character) => limitedCharacterEmbed({ character }))
-  interaction.editReply(`${character.name} sized up the competition.`)
+  interaction.channel?.send(`${character.name} sized up the competition.`)
   const hook = await getHook({
     name: 'Characters',
     channel,

--- a/packages/game/src/commands/list/listEncounters.ts
+++ b/packages/game/src/commands/list/listEncounters.ts
@@ -7,7 +7,7 @@ import {
 
 export function listEncounters(interaction: CommandInteraction): void {
   const encounters = getEncounters()
-  interaction.editReply({
+  interaction.channel?.send({
     embeds:
       encounters.length > 0
         ? encounters

--- a/packages/game/src/commands/list/listMonsters.ts
+++ b/packages/game/src/commands/list/listMonsters.ts
@@ -18,7 +18,7 @@ export async function listMonsters(
   const channel = interaction.channel
   if (!(channel instanceof TextChannel)) return
   if (!roamingMonsters.length) {
-    interaction.followUp({
+    interaction.channel?.send({
       embeds: [
         new EmbedBuilder({
           description:
@@ -28,7 +28,9 @@ export async function listMonsters(
     })
     return
   }
-  interaction.followUp(`${decoratedName(character)} checks the wanted board.`)
+  interaction.channel?.send(
+    `${decoratedName(character)} checks the wanted board.`
+  )
   const thread = await channel.threads.create({
     name: 'Roaming Monsters',
   })

--- a/packages/game/src/commands/newgame.ts
+++ b/packages/game/src/commands/newgame.ts
@@ -20,12 +20,12 @@ export const execute = async ({
   if (!interaction.isChatInputCommand()) return
   const input = interaction.options.getString('when')
   if (!input) {
-    await interaction.editReply('Please specify when you want to start.')
+    await interaction.channel?.send('Please specify when you want to start.')
     return
   }
   const date = chrono.parseDate(input)
   if (!date) {
-    await interaction.editReply('Invalid date.')
+    await interaction.channel?.send('Invalid date.')
     return
   }
   store.dispatch(
@@ -35,7 +35,7 @@ export const execute = async ({
       action: newgame(),
     })
   )
-  await interaction.editReply({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `New game will begin ${moment(date).fromNow()}`,

--- a/packages/game/src/commands/quests.ts
+++ b/packages/game/src/commands/quests.ts
@@ -10,7 +10,10 @@ import {
   Message,
 } from 'discord.js'
 
-import { findOrCreateCharacter } from '@adventure-bot/game/character'
+import {
+  decoratedName,
+  findOrCreateCharacter,
+} from '@adventure-bot/game/character'
 import {
   Quest,
   QuestId,
@@ -43,7 +46,7 @@ export const execute = async ({
     return
   }
   const embed = new EmbedBuilder({
-    title: 'Quests',
+    title: `${decoratedName(character)}'s Quests`,
     color: Colors.Yellow,
   })
   Object.values(character.quests).forEach((quest) => {
@@ -71,7 +74,6 @@ export const execute = async ({
       ...Object.values(character.quests).map(questEmbed),
     ],
     components: getComponents(completedQuests),
-    fetchReply: true,
   })
   if (!(message instanceof Message)) return
   const reply = await message

--- a/packages/game/src/commands/set.ts
+++ b/packages/game/src/commands/set.ts
@@ -30,7 +30,7 @@ export const execute = async ({
     const isValidExtension = (path: string) =>
       new RegExp(`${validExtensions.join('|')}$`).test(path)
     if (!isValidExtension(url.pathname)) {
-      interaction.editReply(
+      interaction.channel?.send(
         [
           `\`${profile}\` must be a one of these valid extensions: ${validExtensions.join(
             ', '
@@ -43,7 +43,7 @@ export const execute = async ({
       return
     }
   } catch (e) {
-    interaction.editReply(
+    interaction.channel?.send(
       [
         `\`${profile}\` must be a valid URL.`,
         'Example:',

--- a/packages/game/src/encounters/angels.ts
+++ b/packages/game/src/encounters/angels.ts
@@ -11,7 +11,6 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export async function angels({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   store.dispatch(
     questGranted({
@@ -22,7 +21,7 @@ export async function angels({
   const character = findOrCreateCharacter(interaction.user)
   const quest = character.quests.healer
 
-  interaction[replyType]({
+  interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} encountered an angel!`,

--- a/packages/game/src/encounters/cairns.ts
+++ b/packages/game/src/encounters/cairns.ts
@@ -66,7 +66,6 @@ const labels: Record<EncounterId, string> = {
 
 export const cairns = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
 
@@ -100,7 +99,7 @@ export const cairns = async ({
     .filter(Boolean)
     .join('\n')
 
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} found guidance in the cairns!`,
@@ -140,7 +139,7 @@ export const cairns = async ({
     .catch(() => null)
   message.edit({ components: [] })
   if (!response?.isButton()) {
-    interaction.followUp(`Destiny does not wait forever.`)
+    interaction.channel?.send(`Destiny does not wait forever.`)
     return
   }
 
@@ -160,8 +159,8 @@ export const cairns = async ({
   }
 
   if (isKeyOfObject(response.customId, handlers)) {
-    handlers[response.customId]({ interaction, replyType: 'followUp' })
+    handlers[response.customId]({ interaction })
   } else {
-    interaction.followUp(`${response.customId} is not a valid option.`)
+    interaction.channel?.send(`${response.customId} is not a valid option.`)
   }
 }

--- a/packages/game/src/encounters/cave.ts
+++ b/packages/game/src/encounters/cave.ts
@@ -24,10 +24,9 @@ import {
 
 export const cave = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} encountered a wonderous cave!`,
@@ -67,7 +66,7 @@ export const cave = async ({
 
   if (!response.isButton()) return
   if (response.customId === 'leave') {
-    await interaction.followUp('You leave the cave.')
+    await interaction.channel?.send('You leave the cave.')
     return
   }
 
@@ -75,5 +74,5 @@ export const cave = async ({
     [1, chest],
     [1, monster],
     [1, trap],
-  ])({ interaction, replyType: 'followUp' })
+  ])({ interaction })
 }

--- a/packages/game/src/encounters/chest/chest.ts
+++ b/packages/game/src/encounters/chest/chest.ts
@@ -37,7 +37,7 @@ export type Chest = {
 }
 
 export async function chest(
-  { interaction, replyType = 'followUp' }: CommandHandlerOptions,
+  { interaction }: CommandHandlerOptions,
   chestConfig?: Partial<Chest>
 ): Promise<void> {
   const character = findOrCreateCharacter(interaction.user)
@@ -65,9 +65,8 @@ export async function chest(
     ...chestConfig,
   }
 
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [chestEmbed(chest, interaction)],
-    fetchReply: true,
   })
   if (!(message instanceof Message)) return
   await message.react(Emoji('perception'))
@@ -154,7 +153,7 @@ export async function chest(
           failureText: "triggered the chest's trap!",
         }).success
       ) {
-        triggerTrap(interaction, chest, message.id)
+        triggerTrap(interaction, chest)
       }
       if (
         statContest({
@@ -173,7 +172,7 @@ export async function chest(
     }
     if (reaction.emoji.name === '👐') {
       if (chest.trapped && !chest.disarmed) {
-        triggerTrap(interaction, chest, message.id)
+        triggerTrap(interaction, chest)
       }
       if (!chest.locked) chest.looted = true
       if (chest.locked) {
@@ -277,11 +276,7 @@ function chestResponses(chest: Chest): string[] {
   return responses
 }
 
-function triggerTrap(
-  interaction: CommandInteraction,
-  chest: Chest,
-  messageId: string
-) {
+function triggerTrap(interaction: CommandInteraction, chest: Chest) {
   const { trap, trapTriggered } = chest
   if (!trap || trapTriggered) return
   chest.trapTriggered = true
@@ -289,6 +284,5 @@ function triggerTrap(
     interaction,
     trap,
     defender: findOrCreateCharacter(interaction.user),
-    messageId,
   })
 }

--- a/packages/game/src/encounters/coralReef.ts
+++ b/packages/game/src/encounters/coralReef.ts
@@ -25,10 +25,9 @@ import {
 
 export async function coralReef({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   const character = findOrCreateCharacter(interaction.user)
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} encountered a coral reef!`,
@@ -67,17 +66,16 @@ export async function coralReef({
 
   if (!response.isButton()) return
   if (response.customId === 'leave') {
-    await interaction.followUp('You leave the reef.')
+    await interaction.channel?.send('You leave the reef.')
     return
   }
   weightedTable<() => void>([
-    [1, () => chest({ interaction, replyType: 'followUp' })],
+    [1, () => chest({ interaction })],
     [
       2,
       () =>
         monster({
           interaction,
-          replyType: 'followUp',
           monster: createMonster(
             weightedTable([
               [1, createShark],

--- a/packages/game/src/encounters/divineBlessing.ts
+++ b/packages/game/src/encounters/divineBlessing.ts
@@ -8,13 +8,12 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export async function divineBlessing({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   store.dispatch(divineBlessingGranted(interaction.user.id))
   const art = asset('fantasy', 'magic', 'a divine blessing')
   const character = findOrCreateCharacter(interaction.user)
 
-  await interaction[replyType]({
+  await interaction.channel?.send({
     files: [art.attachment],
     embeds: [
       new EmbedBuilder({

--- a/packages/game/src/encounters/fairyWell.ts
+++ b/packages/game/src/encounters/fairyWell.ts
@@ -12,12 +12,11 @@ import { CommandHandlerOptions, asset, d } from '@adventure-bot/game/utils'
 
 export async function fairyWell({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   const healAmount = d(6)
 
   const character = findOrCreateCharacter(interaction.user)
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} drank from a fairy's well!`,

--- a/packages/game/src/encounters/monster.ts
+++ b/packages/game/src/encounters/monster.ts
@@ -32,14 +32,14 @@ import { CommandHandlerOptions, d } from '@adventure-bot/game/utils'
 
 export const monster = async ({
   interaction,
-  replyType = 'editReply',
+
   monster = randomMonster(),
 }: CommandHandlerOptions & { monster?: MonsterWithStats }): Promise<void> => {
   let player = findOrCreateCharacter(interaction.user)
   let encounter = createEncounter({ monster, player })
   const encounterId = encounter.id
   let timeout = false
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [encounterEmbed({ encounterId })],
   })
   if (!(message instanceof Message)) return
@@ -101,7 +101,7 @@ export const monster = async ({
           amount: revengeDamage,
         })
       )
-      await interaction.followUp({
+      await interaction.channel?.send({
         embeds: [
           new EmbedBuilder({
             title: 'Revenge!',

--- a/packages/game/src/encounters/ranger.ts
+++ b/packages/game/src/encounters/ranger.ts
@@ -23,7 +23,6 @@ import {
 
 export const ranger = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
   const roamingMonsters = pipe(
@@ -32,7 +31,7 @@ export const ranger = async ({
     take(3)
   )
 
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} encountered a ranger!`,
@@ -90,13 +89,12 @@ export const ranger = async ({
     (monster) => monster.id === response.customId
   )
   if (!selectedMonster) {
-    await interaction.followUp('Monster not found.')
+    await interaction.channel?.send('Monster not found.')
     return
   }
 
   await monsterEncounter({
     interaction,
     monster: selectedMonster,
-    replyType: 'followUp',
   })
 }

--- a/packages/game/src/encounters/shop/sellItemPrompt.ts
+++ b/packages/game/src/encounters/shop/sellItemPrompt.ts
@@ -83,7 +83,7 @@ export async function sellItemPrompt({
     })
   )
 
-  interaction.followUp({
+  interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${character.name} sold their ${item.name}.`,

--- a/packages/game/src/encounters/shop/shop.ts
+++ b/packages/game/src/encounters/shop/shop.ts
@@ -31,13 +31,12 @@ const inventory = () => selectShopInventory(store.getState())
 
 export const shop = async ({
   interaction,
-  replyType = 'followUp',
 }: CommandHandlerOptions): Promise<void> => {
   store.dispatch(shopRestocked())
   if (didFindCrown()) {
     store.dispatch(shopInventoryAdded(heavyCrown()))
   }
-  const message = await interaction[replyType](shopMain(interaction))
+  const message = await interaction.channel?.send(shopMain(interaction))
   if (!(message instanceof Message)) return
   let hasLeft = false
   while (!hasLeft) {

--- a/packages/game/src/encounters/shrine/Shrine.ts
+++ b/packages/game/src/encounters/shrine/Shrine.ts
@@ -17,10 +17,9 @@ export type Shrine = {
 export async function shrineEncounter({
   shrine,
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions & { shrine: Shrine }): Promise<void> {
-  const { id: messageId } = await interaction[replyType]({
+  await interaction.channel?.send({
     embeds: shrineEmbeds({ shrine, interaction }),
   })
-  applyShrine({ shrine, interaction, messageId })
+  applyShrine({ shrine, interaction })
 }

--- a/packages/game/src/encounters/shrine/applyShrine.ts
+++ b/packages/game/src/encounters/shrine/applyShrine.ts
@@ -15,7 +15,6 @@ export async function applyShrine({
 }: {
   interaction: CommandInteraction
   shrine: Shrine
-  messageId: string
 }): Promise<void> {
   const character = findOrCreateCharacter(interaction.user)
   const effect = shrine.effect

--- a/packages/game/src/encounters/shrine/armor.ts
+++ b/packages/game/src/encounters/shrine/armor.ts
@@ -7,11 +7,10 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export const armorShrine = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   return shrineEncounter({
     interaction,
-    replyType,
+
     shrine: {
       id: randomUUID(),
       color: Colors.Yellow,

--- a/packages/game/src/encounters/shrine/attack.ts
+++ b/packages/game/src/encounters/shrine/attack.ts
@@ -7,11 +7,10 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export const attackShrine = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   return shrineEncounter({
     interaction,
-    replyType,
+
     shrine: {
       id: randomUUID(),
       name: 'Shrine of Agression',

--- a/packages/game/src/encounters/shrine/rogue.ts
+++ b/packages/game/src/encounters/shrine/rogue.ts
@@ -7,7 +7,6 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export async function roguesGuild({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   return shrineEncounter({
     shrine: {
@@ -19,6 +18,5 @@ export async function roguesGuild({
       effect: createEffect('rogue'),
     },
     interaction,
-    replyType,
   })
 }

--- a/packages/game/src/encounters/shrine/slayer.ts
+++ b/packages/game/src/encounters/shrine/slayer.ts
@@ -7,11 +7,10 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export const slayerShrine = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   return shrineEncounter({
     interaction,
-    replyType,
+
     shrine: {
       id: randomUUID(),
       name: "Slayer's Shrine",

--- a/packages/game/src/encounters/shrine/vigor.ts
+++ b/packages/game/src/encounters/shrine/vigor.ts
@@ -7,11 +7,10 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export async function vigorShrine({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   return shrineEncounter({
     interaction,
-    replyType,
+
     shrine: {
       id: randomUUID(),
       name: 'Vigor Shrine',

--- a/packages/game/src/encounters/tavern/chattyTavernkeepers.ts
+++ b/packages/game/src/encounters/tavern/chattyTavernkeepers.ts
@@ -31,7 +31,7 @@ export const chattyTavernkeepers = async (
   const availableQuests = selectAvailableQuests(state, character)
 
   if (availableQuests.length === 0) {
-    interaction.followUp({
+    interaction.channel?.send({
       embeds: [
         new EmbedBuilder({
           title: `${decoratedName(character)} met a chatty tavernkeeper!`,
@@ -43,8 +43,7 @@ export const chattyTavernkeepers = async (
     })
     return
   }
-  const message = await interaction.followUp({
-    fetchReply: true,
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} met a chatty tavernkeeper!`,
@@ -83,17 +82,17 @@ export const chattyTavernkeepers = async (
       time: 60000,
     })
     .catch(() => {
-      interaction.followUp('Another time, perhaps!')
+      interaction.channel?.send('Another time, perhaps!')
     })
   if (!response) return
   const questId = response.values[0]
   response.valueOf()
   if (!isQuestId(questId)) {
-    interaction.followUp(`${questId} is not a valid quest id`)
+    interaction.channel?.send(`${questId} is not a valid quest id`)
     return
   }
   store.dispatch(questGranted({ characterId: character.id, questId }))
-  await interaction.followUp(
+  await interaction.channel?.send(
     `${decoratedName(character)} was charged with the ${
       quests[questId].title
     } quest.`

--- a/packages/game/src/encounters/tavern/restfulNight.ts
+++ b/packages/game/src/encounters/tavern/restfulNight.ts
@@ -24,7 +24,7 @@ export async function restfulNight(
   )
   const character = findOrCreateCharacter(interaction.user)
 
-  await interaction.followUp({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} had a restful night.`,

--- a/packages/game/src/encounters/tavern/tavern.ts
+++ b/packages/game/src/encounters/tavern/tavern.ts
@@ -18,10 +18,9 @@ import { asset } from '@adventure-bot/game/utils'
 
 export const tavern = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} found a tavern.`,

--- a/packages/game/src/encounters/townsquare.ts
+++ b/packages/game/src/encounters/townsquare.ts
@@ -23,10 +23,9 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export const townSquare = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
-  const message = await interaction[replyType]({
+  const message = await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} has arrived at the town square!`,
@@ -81,18 +80,15 @@ export const townSquare = async ({
     .finally(() => message.edit({ components: [] }))
 
   if (!response.isButton()) return
-  if (response.customId === 'shop')
-    await shop.execute({ interaction, replyType: 'followUp' })
-  if (response.customId === 'tavern')
-    await tavern({ interaction, replyType: 'followUp' })
+  if (response.customId === 'shop') await shop.execute({ interaction })
+  if (response.customId === 'tavern') await tavern({ interaction })
   if (response.customId === 'dark_alley') {
     if (statContest({ character, stat: 'luck', difficulty: 14 }).success) {
-      await roguesGuild({ interaction, replyType: 'followUp' })
+      await roguesGuild({ interaction })
     } else {
       await monster({
         monster: createMonster(createTabaxi()),
         interaction,
-        replyType: 'followUp',
       })
     }
   }

--- a/packages/game/src/encounters/trap.ts
+++ b/packages/game/src/encounters/trap.ts
@@ -13,7 +13,7 @@ import { CommandHandlerOptions, sleep } from '@adventure-bot/game/utils'
 
 export const trap = async ({
   interaction,
-  replyType = 'editReply',
+
   trap = getRandomTrap(),
 }: CommandHandlerOptions & { trap?: TrapWithStats }): Promise<void> => {
   const character = findOrCreateCharacter(interaction.user)
@@ -26,9 +26,9 @@ export const trap = async ({
     .setImage(trap.profile)
     .setThumbnail(character.profile)
 
-  const { id: messageId } = await interaction[replyType]({
+  await interaction.channel?.send({
     embeds: [embed],
   })
   await sleep(2000)
-  trapAttack({ interaction, defender: character, trap, messageId })
+  trapAttack({ interaction, defender: character, trap })
 }

--- a/packages/game/src/encounters/travel.ts
+++ b/packages/game/src/encounters/travel.ts
@@ -17,7 +17,6 @@ import { CommandHandlerOptions, asset, d } from '@adventure-bot/game/utils'
 
 export const travel = async ({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> => {
   updateQuestProgess({
     interaction,
@@ -26,7 +25,7 @@ export const travel = async ({
     amount: 1,
   })
   const character = findOrCreateCharacter(interaction.user)
-  await interaction[replyType]({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} traveled.`,

--- a/packages/game/src/encounters/warlock.ts
+++ b/packages/game/src/encounters/warlock.ts
@@ -11,7 +11,6 @@ import { CommandHandlerOptions, asset } from '@adventure-bot/game/utils'
 
 export async function warlock({
   interaction,
-  replyType = 'editReply',
 }: CommandHandlerOptions): Promise<void> {
   store.dispatch(
     questGranted({
@@ -23,7 +22,7 @@ export async function warlock({
   const character = findOrCreateCharacter(interaction.user)
   const quest = character.quests.afflicted
 
-  await interaction[replyType]({
+  await interaction.channel?.send({
     embeds: [
       new EmbedBuilder({
         title: `${decoratedName(character)} encountered a warlock!`,

--- a/packages/game/src/equipment/equipInventoryItemPrompt.ts
+++ b/packages/game/src/equipment/equipInventoryItemPrompt.ts
@@ -23,12 +23,12 @@ export const equipInventoryItemPrompt = async (
   const character = findOrCreateCharacter(interaction.user)
   const inventory = equippableInventory(character)
   if (inventory.length === 0) {
-    interaction.editReply({
+    interaction.channel?.send({
       content: 'No inventory items available to equip',
     })
     return
   }
-  const message = await interaction.followUp({
+  const message = await interaction.channel?.send({
     content: 'What would you like to equip?',
     components: [
       new ActionRowBuilder<SelectMenuBuilder>({
@@ -77,7 +77,9 @@ export const equipInventoryItemPrompt = async (
       store.dispatch(
         itemEquipped({ itemId: item.id, characterId: character.id })
       )
-      interaction.followUp(`${character.name} equipped their ${item.name}.`)
+      interaction.channel?.send(
+        `${character.name} equipped their ${item.name}.`
+      )
     }
   }
 }

--- a/packages/game/src/equipment/equipItemPrompt.ts
+++ b/packages/game/src/equipment/equipItemPrompt.ts
@@ -28,7 +28,7 @@ export async function equipItemPrompt({
   showItem?: boolean
 }): Promise<void> {
   const content = `Would you like to equip the ${item.name}?`
-  const message = await interaction.followUp({
+  const message = await interaction.channel?.send({
     content,
     embeds: showItem ? [itemEmbed({ item })] : [],
     components: [

--- a/packages/game/src/equipment/offerItemPrompt.ts
+++ b/packages/game/src/equipment/offerItemPrompt.ts
@@ -26,10 +26,10 @@ export const offerItemPrompt = async (
   const sender = findOrCreateCharacter(interaction.user)
   const inventory = sender.inventory.filter(isTradeable)
   if (inventory.length === 0) {
-    interaction.followUp(`No items to offer.`)
+    interaction.channel?.send(`No items to offer.`)
     return
   }
-  const message = await interaction.followUp({
+  const message = await interaction.channel?.send({
     content:
       'Offer an item for grabs. First to click gets it. If time expires, it will become dust in the wind.',
     components: [
@@ -77,8 +77,7 @@ export const offerItemPrompt = async (
   const item = inventory[parseInt(response.values[0])]
   if (timeout || !item) return
   if (!item) return
-  const offer = await interaction.followUp({
-    fetchReply: true,
+  const offer = await interaction.channel?.send({
     content: `${sender.name} offers their ${item.name}.`,
     embeds: [itemEmbed({ item })],
     components: [
@@ -122,6 +121,8 @@ export const offerItemPrompt = async (
       })
     )
     offer.edit({ components: [] })
-    interaction.followUp(`${recipient.name} took ${sender.name}'s ${item.name}`)
+    interaction.channel?.send(
+      `${recipient.name} took ${sender.name}'s ${item.name}`
+    )
   }
 }

--- a/packages/game/src/equipment/useInventoryItemPrompt.ts
+++ b/packages/game/src/equipment/useInventoryItemPrompt.ts
@@ -36,12 +36,12 @@ export const useInventoryItemPrompt = async (
   const character = findOrCreateCharacter(interaction.user)
   const inventory = usableInventory(character)
   if (inventory.length === 0) {
-    interaction.editReply({
+    interaction.channel?.send({
       content: 'No inventory items available to use',
     })
     return
   }
-  const message = await interaction.followUp({
+  const message = await interaction.channel?.send({
     content: 'What would you like to use?',
     components: [
       new ActionRowBuilder<StringSelectMenuBuilder>({
@@ -115,7 +115,7 @@ async function useInventoryItem({
     }).setThumbnail(character.profile)
     if (item.asset)
       embed.setImage(asset('fantasy', 'items', item.asset, item.id).s3Url)
-    await interaction.followUp({
+    await interaction.channel?.send({
       embeds: [embed],
     })
     store.dispatch(itemRemoved({ itemId, characterId }))

--- a/packages/game/src/quest/rewards/buffQuestReward.ts
+++ b/packages/game/src/quest/rewards/buffQuestReward.ts
@@ -21,7 +21,7 @@ export async function buffQuestReward(
     }),
   ]
 
-  await interaction.followUp({
+  await interaction.channel?.send({
     embeds,
   })
   store.dispatch(

--- a/packages/game/src/store/actions/index.ts
+++ b/packages/game/src/store/actions/index.ts
@@ -19,7 +19,7 @@ export const itemReceived = createAction<{
 }>('itemReceived')
 export const backdateCrown = createAction('backdateCrown') // for testing
 export const trapAttacked =
-  createAction<{ result: TrapAttackResult; messageId: string }>('trapAttacked')
+  createAction<{ result: TrapAttackResult }>('trapAttacked')
 
 export const characterMessageCreated = createAction<{
   character: Character

--- a/packages/game/src/trap/trapAttack.ts
+++ b/packages/game/src/trap/trapAttack.ts
@@ -15,12 +15,10 @@ export function trapAttack({
   interaction,
   defender,
   trap,
-  messageId,
 }: {
   interaction: CommandInteraction
   defender: CharacterWithStats
   trap: TrapWithStats
-  messageId: string
 }): TrapAttackResult {
   const attackRoll = d20()
   const { attackBonus, damageMax } = trap
@@ -37,7 +35,7 @@ export function trapAttack({
     defender,
     trap,
   }
-  store.dispatch(trapAttacked({ result, messageId }))
+  store.dispatch(trapAttacked({ result }))
 
   if ('hit' === outcome && trap.onHitEffect)
     store.dispatch(

--- a/packages/game/src/utils/index.ts
+++ b/packages/game/src/utils/index.ts
@@ -23,7 +23,6 @@ export const sleep = (milliseconds: number): Promise<void> =>
 
 export type CommandHandlerOptions = {
   interaction: CommandInteraction
-  replyType?: 'editReply' | 'followUp'
 }
 
 export type CommandHandler = (options: CommandHandlerOptions) => Promise<void>


### PR DESCRIPTION
Consolidate all response types to `channel.send`. Removes need for any knowledge of `replyType` and generally simplifies things.